### PR TITLE
feat(decorative): add 5 new decorative patterns

### DIFF
--- a/src/app/utils/patterns.ts
+++ b/src/app/utils/patterns.ts
@@ -1,6 +1,37 @@
 import { Pattern } from "../types/pattern";
 
 export const gridPatterns: Pattern[] = [
+
+  {
+  id: "tri-point-blend",
+  name: "Tri-Point Blend",
+  badge: "New",
+  category: "decorative",
+  style: {
+    background: "#fafafa",
+    backgroundImage: `
+      radial-gradient(circle at 0%   0%,   #ff9a8b 0%, transparent 50%),
+      radial-gradient(circle at 100% 0%,   #ffd3b5 0%, transparent 50%),
+      radial-gradient(circle at 50%  100%, #6a90f2 0%, transparent 50%)
+    `,
+    backgroundSize: "cover",
+  },
+  code: `<div className="min-h-screen w-full bg-white relative">
+  {/* Tri-Point Blend Background */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      backgroundImage: \`
+        radial-gradient(circle at 0%   0%,   #ff9a8b 0%, transparent 50%),
+        radial-gradient(circle at 100% 0%,   #ffd3b5 0%, transparent 50%),
+        radial-gradient(circle at 50%  100%, #6a90f2 0%, transparent 50%)
+      \`,
+      backgroundSize: "cover",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+},
   {
     id: "purple-gradient-grid-right",
     name: "Purple Gradient Grid Right",
@@ -31,6 +62,112 @@ export const gridPatterns: Pattern[] = [
    {/* Your Content/Components */}
 </div>`,
   },
+  {
+  id: "radial-teal-glow",
+  name: "Teal Glow",
+  badge: "New",
+  category: "decorative",
+  style: {
+    background: "#ffffff",
+    backgroundImage: `
+      radial-gradient(125% 125% at 50% 90%, #ffffff 40%, #14b8a6 100%)
+    `,
+    backgroundSize: "100% 100%",
+  },
+  code: `<div className="min-h-screen w-full bg-white relative">
+  {/* Teal Glow Background */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      backgroundImage: \`
+        radial-gradient(125% 125% at 50% 90%, #ffffff 40%, #14b8a6 100%)
+      \`,
+      backgroundSize: "100% 100%",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+},
+{
+  id: "radial-pink-glow",
+  name: "Pink Glow",
+  badge: "New",
+  category: "decorative",
+  style: {
+    background: "#ffffff",
+    backgroundImage: `
+      radial-gradient(125% 125% at 50% 90%, #ffffff 40%, #ec4899 100%)
+    `,
+    backgroundSize: "100% 100%",
+  },
+  code: `<div className="min-h-screen w-full bg-white relative">
+  {/* Pink Glow Background */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      backgroundImage: \`
+        radial-gradient(125% 125% at 50% 90%, #ffffff 40%, #ec4899 100%)
+      \`,
+      backgroundSize: "100% 100%",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+},
+{
+  id: "radial-amber-glow",
+  name: "Amber Glow",
+  badge: "New",
+  category: "decorative",
+  style: {
+    background: "#ffffff",
+    backgroundImage: `
+      radial-gradient(125% 125% at 50% 90%, #ffffff 40%, #f59e0b 100%)
+    `,
+    backgroundSize: "100% 100%",
+  },
+  code: `<div className="min-h-screen w-full bg-white relative">
+  {/* Amber Glow Background */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      backgroundImage: \`
+        radial-gradient(125% 125% at 50% 90%, #ffffff 40%, #f59e0b 100%)
+      \`,
+      backgroundSize: "100% 100%",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+},
+{
+  id: "radial-emerald-glow",
+  name: "Emerald Glow",
+  badge: "New",
+  category: "decorative",
+  style: {
+    background: "#ffffff",
+    backgroundImage: `
+      radial-gradient(125% 125% at 50% 90%, #ffffff 40%, #10b981 100%)
+    `,
+    backgroundSize: "100% 100%",
+  },
+  code: `<div className="min-h-screen w-full bg-white relative">
+  {/* Emerald Glow Background */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      backgroundImage: \`
+        radial-gradient(125% 125% at 50% 90%, #ffffff 40%, #10b981 100%)
+      \`,
+      backgroundSize: "100% 100%",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+},
+
+
   {
     id: "purple-gradient-grid-left",
     name: "Purple Gradient Grid Left",


### PR DESCRIPTION
feat(decorative): add 5 new radial-gradient patterns

## 📝 Summary
This PR introduces five new radial-gradient backgrounds in the **Decorative** section.  
Each effect adds a soft “glow” from different hues, anchored near the bottom center.

---

## ✨ Patterns Added
1. `tri-point-blend`  — Tri-Point Blend
2. `radial-teal-glow`    — Teal Glow  
3. `radial-pink-glow`    — Pink Glow  
4. `radial-amber-glow`   — Amber Glow  
5. `radial-emerald-glow` — Emerald Glow  

---

## 👀 Previews

### 1. Tri-Point Blend
![Screenshot 2025-06-22 150557](https://github.com/user-attachments/assets/05fcfa12-ad88-437d-91e0-ddbc452a99c0)

### 2. Teal Glow
![image](https://github.com/user-attachments/assets/3ff1c459-f669-4b9f-9fdf-10760484554c)

### 3. Pink Glow
![image](https://github.com/user-attachments/assets/3e343a5a-ee02-4ea1-8630-b34c758e9a6e)

### 4. Amber Glow
![image](https://github.com/user-attachments/assets/5486e6d6-df49-421a-873d-32ed19c85c52)

### 5. Emerald Glow
![image](https://github.com/user-attachments/assets/83dee8a6-c7e3-490e-9ffa-1d03b87f1b16)

---
Thanks for reviewing! 