### PR TITLE
feat(patterns): add dark radial gradient collection in decorative sec…

### DIFF
--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://patterncraft.megh.me</loc><lastmod>2025-06-25T09:57:42.251Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://patterncraft.megh.me</loc><lastmod>2025-07-02T05:44:31.322Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/utils/patterns.ts
+++ b/src/app/utils/patterns.ts
@@ -41,14 +41,15 @@ export const gridPatterns: Pattern[] = [
      {/* Your Content/Components */}
 </div>`,
   },
-    {
+  {
     id: "bottom-violet-radial",
     name: "Bottom Violet Radial",
     category: "decorative",
     badge: "New",
     description: "Rich violet from bottom - luxury feel for premium brands",
     style: {
-      background: "radial-gradient(125% 125% at 50% 90%, #fff 40%, #7c3aed 100%)",
+      background:
+        "radial-gradient(125% 125% at 50% 90%, #fff 40%, #7c3aed 100%)",
     },
     code: `<div className="min-h-screen w-full relative">
   {/* Radial Gradient Background from Bottom */}
@@ -68,7 +69,8 @@ export const gridPatterns: Pattern[] = [
     badge: "New",
     description: "Sophisticated slate from bottom - clean and professional",
     style: {
-      background: "radial-gradient(125% 125% at 50% 90%, #fff 40%, #475569 100%)",
+      background:
+        "radial-gradient(125% 125% at 50% 90%, #fff 40%, #475569 100%)",
     },
     code: `<div className="min-h-screen w-full relative">
   {/* Radial Gradient Background from Bottom */}
@@ -180,6 +182,258 @@ export const gridPatterns: Pattern[] = [
         radial-gradient(125% 125% at 50% 90%, #ffffff 40%, #10b981 100%)
       \`,
       backgroundSize: "100% 100%",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+  },
+  // dark one
+  {
+    id: "dark-horizon-glow",
+    name: "Dark Horizon Glow",
+    badge: "New",
+    category: "decorative",
+    style: {
+      background: "#000000",
+      backgroundImage: `
+     radial-gradient(125% 125% at 50% 90%, #000000 40%, #0d1a36 100%)
+    `,
+      backgroundSize: "100% 100%",
+    },
+    code: `<div className="min-h-screen w-full relative">
+        {/* Dark Horizon Glow */}
+        <div
+          className="absolute inset-0 z-0"
+          style={{
+            background: "radial-gradient(125% 125% at 50% 90%, #000000 40%, #0d1a36 100%)",
+          }}
+        />
+        {/* Your Content/Components */}
+  
+      </div>`,
+  },
+  {
+    id: "crimson-depth",
+    name: "Crimson Depth",
+    badge: "New",
+    category: "decorative",
+    style: {
+      background: "#000000",
+      backgroundImage: `radial-gradient(125% 125% at 50% 100%, #000000 40%, #2b0707 100%)`,
+      backgroundSize: "100% 100%",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Crimson Depth */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: "radial-gradient(125% 125% at 50% 100%, #000000 40%, #2b0707 100%)",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+  },
+  {
+    id: "emerald-void",
+    name: "Emerald Void",
+    badge: "New",
+    category: "decorative",
+    style: {
+      background: "#000000",
+      backgroundImage: `radial-gradient(125% 125% at 50% 90%, #000000 40%, #072607 100%)`,
+      backgroundSize: "100% 100%",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Emerald Void */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: "radial-gradient(125% 125% at 50% 90%, #000000 40%, #072607 100%)",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+  },
+  {
+    id: "violet-abyss",
+    name: "Violet Abyss",
+    badge: "New",
+    category: "decorative",
+    style: {
+      background: "#000000",
+      backgroundImage: `radial-gradient(125% 125% at 50% 90%, #000000 40%, #2b092b 100%)`,
+      backgroundSize: "100% 100%",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Violet Abyss */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: "radial-gradient(125% 125% at 50% 90%, #000000 40%, #2b092b 100%)",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+  },
+  {
+    id: "azure-depths",
+    name: "Azure Depths",
+    badge: "New",
+    category: "decorative",
+    style: {
+      background: "#000000",
+      backgroundImage: `radial-gradient(125% 125% at 50% 100%, #000000 40%, #010133 100%)`,
+      backgroundSize: "100% 100%",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Azure Depths */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: "radial-gradient(125% 125% at 50% 100%, #000000 40%, #010133 100%)",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+  },
+  {
+    id: "orchid -depths",
+    name: "Orchid  Depths",
+    badge: "New",
+    category: "decorative",
+    style: {
+      background: "#000000",
+      backgroundImage: `radial-gradient(125% 125% at 50% 100%, #000000 40%, #350136 100%)`,
+      backgroundSize: "100% 100%",
+    },
+    code: `<div className="min-h-screen w-full relative">
+        {/* Azure Depths */}
+        <div
+          className="absolute inset-0 z-0"
+          style={{
+            background: "radial-gradient(125% 125% at 50% 100%, #000000 40%, #350136 100%)",
+          }}
+        />
+        {/* Your Content/Components */}
+
+      </div>`,
+  },
+  //top
+  {
+    id: "dark-horizon-glow-top",
+    name: "Dark Horizon Glow Top",
+    badge: "New",
+    category: "decorative",
+    style: {
+      background:
+        "radial-gradient(125% 125% at 50% 10%, #000000 40%, #0d1a36 100%)",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Dark Horizon Glow */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: "radial-gradient(125% 125% at 50% 10%, #000000 40%, #0d1a36 100%)",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+  },
+  {
+    id: "crimson-depth-top",
+    name: "Crimson Depth Top",
+    badge: "New",
+    category: "decorative",
+    style: {
+      background:
+        "radial-gradient(125% 125% at 50% 10%, #000000 40%, #2b0707 100%)",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Crimson Depth */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: "radial-gradient(125% 125% at 50% 10%, #000000 40%, #2b0707 100%)",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+  },
+  {
+    id: "emerald-void-top",
+    name: "Emerald Void Top",
+    badge: "New",
+    category: "decorative",
+    style: {
+      background:
+        "radial-gradient(125% 125% at 50% 10%, #000000 40%, #072607 100%)",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Emerald Void */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: "radial-gradient(125% 125% at 50% 10%, #000000 40%, #072607 100%)",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+  },
+  {
+    id: "violet-abyss-top",
+    name: "Violet Abyss Top",
+    badge: "New",
+    category: "decorative",
+    style: {
+      background:
+        "radial-gradient(125% 125% at 50% 10%, #000000 40%, #2b092b 100%)",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Violet Abyss */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: "radial-gradient(125% 125% at 50% 10%, #000000 40%, #2b092b 100%)",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+  },
+  {
+    id: "azure-depths-top",
+    name: "Azure Depths Top",
+    badge: "New",
+    category: "decorative",
+    style: {
+      background:
+        "radial-gradient(125% 125% at 50% 10%, #000000 40%, #010133 100%)",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Azure Depths */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: "radial-gradient(125% 125% at 50% 10%, #000000 40%, #010133 100%)",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+  },
+  {
+    id: "orchid-depths-top",
+    name: "Orchid Depths Top",
+    badge: "New",
+    category: "decorative",
+    style: {
+      background:
+        "radial-gradient(125% 125% at 50% 10%, #000000 40%, #350136 100%)",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Orchid Depths */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: "radial-gradient(125% 125% at 50% 10%, #000000 40%, #350136 100%)",
     }}
   />
   {/* Your Content/Components */}


### PR DESCRIPTION
# Add Dark Radial Gradient Pattern Collection

## Overview
Added 12 new dark-themed radial gradient patterns with black centers and colored edges.

## New Patterns
- **Dark Horizon Glow** - Navy blue accent
- **Crimson Depth** - Deep red accent  
- **Emerald Void** - Dark green accent
- **Violet Abyss** - Purple accent
- **Azure Depths** - Deep blue accent
- **Orchid Depths** - Magenta accent
- **Dark Horizon Glow Top** - Navy blue accent
- **Crimson Depth Top** - Deep red accent  
- **Emerald Void Top** - Dark green accent
- **Violet Abyss Top** - Purple accent
- **Azure Depths Top** - Deep blue accent
- **Orchid Depths Top** - Magenta accent

## Changes
- All patterns use `radial-gradient(125% 125% at 50% 10%, #000000 40%, [color] 100%)`
- Added to decorative category with "New" badge
- Consistent with existing Pattern Craft schema

Perfect for dark-themed websites and modern applications.

![image](https://github.com/user-attachments/assets/fd652a63-39f9-4298-9a86-33d6109b1a1c)
