### PR TITLE
Add ❤️ Save Favorites Feature with LocalStorage Support

### DIFF
--- a/src/app/components/pattern-showcase.tsx
+++ b/src/app/components/pattern-showcase.tsx
@@ -1,12 +1,11 @@
 "use client";
-
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@radix-ui/react-tabs";
 import { Check, Copy, Eye, Sparkles } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { gridPatterns } from "../utils/patterns";
-import { useState } from "react";
 
 interface PatternShowcaseProps {
   activePattern: string | null;
@@ -20,9 +19,27 @@ export default function PatternShowcase({
   theme,
 }: PatternShowcaseProps) {
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [favorites, setFavorites] = useState<string[]>([]);
   const [activeMobileCard, setActiveMobileCard] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<string>("all");
   const isPatternDark = theme === "dark";
+
+  // Load favorites on mount
+  useEffect(() => {
+    const stored = localStorage.getItem("favorites");
+    if (stored) setFavorites(JSON.parse(stored));
+  }, []);
+
+  // Save favorites to localStorage whenever updated
+  useEffect(() => {
+    localStorage.setItem("favorites", JSON.stringify(favorites));
+  }, [favorites]);
+
+  const toggleFavorite = (id: string) => {
+    setFavorites((prev) =>
+      prev.includes(id) ? prev.filter((fav) => fav !== id) : [...prev, id]
+    );
+  };
 
   // Patterns Categories
 
@@ -32,14 +49,18 @@ export default function PatternShowcase({
     { id: "geometric", label: "Geometric" },
     { id: "decorative", label: "Decorative" },
     { id: "effects", label: "Effects" },
+    { id: "favorites", label: "Saved ❤️" }
   ];
 
   // filter patterns based on categories
 
-  const filteredPatterns =
-    activeTab === "all"
-      ? gridPatterns
-      : gridPatterns.filter((pattern) => pattern.category === activeTab);
+const filteredPatterns =
+  activeTab === "all"
+    ? gridPatterns
+    : activeTab === "favorites"
+    ? gridPatterns.filter((pattern) => favorites.includes(pattern.id))
+    : gridPatterns.filter((pattern) => pattern.category === activeTab);
+
 
   const copyToClipboard = async (code: string, id: string) => {
     try {
@@ -72,14 +93,16 @@ export default function PatternShowcase({
       <div className="mb-8 sm:mb-10 lg:mb-12">
         <div className="text-center sm:text-left">
           <h2
-            className={`text-2xl sm:text-3xl lg:text-4xl font-bold mb-2 transition-colors duration-300 ${isPatternDark ? "text-white" : "text-gray-900 dark:text-gray-50"
-              }`}
+            className={`text-2xl sm:text-3xl lg:text-4xl font-bold mb-2 transition-colors duration-300 ${
+              isPatternDark ? "text-white" : "text-gray-900 dark:text-gray-50"
+            }`}
           >
             Pattern Library
           </h2>
           <p
-            className={`text-sm sm:text-base transition-colors duration-300 ${isPatternDark ? "text-gray-300" : "text-muted-foreground"
-              }`}
+            className={`text-sm sm:text-base transition-colors duration-300 ${
+              isPatternDark ? "text-gray-300" : "text-muted-foreground"
+            }`}
           >
             Tap on mobile or hover on desktop to see options
           </p>
@@ -96,14 +119,15 @@ export default function PatternShowcase({
         <TabsList
           className={`
     hidden sm:grid
-    grid-cols-2 sm:grid-cols-3 md:grid-cols-5
+    grid-cols-2 sm:grid-cols-3 md:grid-cols-6
     w-full h-auto p-1.5
     backdrop-blur-md shadow-lg border
     rounded-xl mb-8 transition-all duration-300
-    ${isPatternDark
-              ? "bg-black/20 border-white/10 hover:bg-black/30"
-              : "bg-white/70 border-gray-200/30 hover:bg-white/80"
-            }
+    ${
+      isPatternDark
+        ? "bg-black/20 border-white/10 hover:bg-black/30"
+        : "bg-white/70 border-gray-200/30 hover:bg-white/80"
+    }
   `}
         >
           {categories.map((category) => (
@@ -119,30 +143,32 @@ export default function PatternShowcase({
         min-h-[44px] sm:min-h-[40px]
         relative overflow-hidden
         group
-        ${isPatternDark
-                  ? `data-[state=active]:bg-white/10 data-[state=active]:text-white 
+        ${
+          isPatternDark
+            ? `data-[state=active]:bg-white/10 data-[state=active]:text-white 
                data-[state=active]:shadow-lg data-[state=active]:border 
                data-[state=active]:border-white/20 data-[state=active]:backdrop-blur-sm
                data-[state=inactive]:text-gray-300 
                data-[state=inactive]:hover:text-white
                data-[state=inactive]:hover:bg-white/5`
-                  : `data-[state=active]:bg-white/90 data-[state=active]:text-gray-900 
+            : `data-[state=active]:bg-white/90 data-[state=active]:text-gray-900 
                data-[state=active]:shadow-lg data-[state=active]:border 
                data-[state=active]:border-gray-200/40 data-[state=active]:backdrop-blur-sm
                data-[state=inactive]:text-gray-600 
                data-[state=inactive]:hover:text-gray-900
                data-[state=inactive]:hover:bg-white/40`
-                }
+        }
       `}
             >
               <div
                 className={`
           absolute inset-0 rounded-lg opacity-0 
           data-[state=active]:opacity-100 transition-all duration-300
-          ${isPatternDark
-                    ? "bg-gradient-to-br from-white/15 to-white/5"
-                    : "bg-gradient-to-br from-white/95 to-white/80"
-                  }
+          ${
+            isPatternDark
+              ? "bg-gradient-to-br from-white/15 to-white/5"
+              : "bg-gradient-to-br from-white/95 to-white/80"
+          }
         `}
               />
               <span className="font-medium z-10 text-center leading-tight">
@@ -172,14 +198,15 @@ export default function PatternShowcase({
           text-sm font-medium transition-all duration-300 ease-in-out
           backdrop-blur-md shadow-lg border
           hover:scale-[1.02] hover:shadow-xl
-          ${activeTab === category.id
-                    ? isPatternDark
-                      ? "bg-white/15 text-white border-white/20 shadow-lg"
-                      : "bg-white/90 text-gray-900 border-gray-200/40 shadow-lg"
-                    : isPatternDark
-                      ? "bg-black/20 text-gray-300 border-white/10 hover:bg-black/30 hover:text-white hover:border-white/20"
-                      : "bg-white/60 text-gray-600 border-gray-200/30 hover:bg-white/80 hover:text-gray-900 hover:border-gray-300/40"
-                  }
+          ${
+            activeTab === category.id
+              ? isPatternDark
+                ? "bg-white/15 text-white border-white/20 shadow-lg"
+                : "bg-white/90 text-gray-900 border-gray-200/40 shadow-lg"
+              : isPatternDark
+              ? "bg-black/20 text-gray-300 border-white/10 hover:bg-black/30 hover:text-white hover:border-white/20"
+              : "bg-white/60 text-gray-600 border-gray-200/30 hover:bg-white/80 hover:text-gray-900 hover:border-gray-300/40"
+          }
         `}
               >
                 <span>{category.label}</span>
@@ -193,8 +220,9 @@ export default function PatternShowcase({
             {/* Pattern count */}
             <div className="mb-6">
               <p
-                className={`text-sm transition-colors duration-300 ${isPatternDark ? "text-gray-300" : "text-muted-foreground"
-                  }`}
+                className={`text-sm transition-colors duration-300 ${
+                  isPatternDark ? "text-gray-300" : "text-muted-foreground"
+                }`}
               >
                 {filteredPatterns.length} pattern
                 {filteredPatterns.length !== 1 ? "s" : ""}
@@ -207,15 +235,28 @@ export default function PatternShowcase({
               {filteredPatterns.map((pattern) => (
                 <div key={pattern.id} className="group relative">
                   <div
-                    className={`relative aspect-square rounded-xl sm:rounded-2xl overflow-hidden bg-background shadow-sm transition-all duration-300 ${activePattern === pattern.id
+                    className={`relative aspect-square rounded-xl sm:rounded-2xl overflow-hidden bg-background shadow-sm transition-all duration-300 ${
+                      activePattern === pattern.id
                         ? "ring-2 ring-primary ring-offset-2"
                         : ""
-                      } ${activeMobileCard === pattern.id
+                    } ${
+                      activeMobileCard === pattern.id
                         ? "scale-[1.02] shadow-lg sm:scale-100"
                         : "hover:shadow-lg hover:scale-[1.02]"
-                      }`}
+                    }`}
                     onClick={() => handleCardInteraction(pattern.id)}
                   >
+                    {/* Favorite Button */}
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleFavorite(pattern.id);
+                      }}
+                      className="absolute top-2 left-2 z-10 text-white text-lg sm:text-xl transition-transform hover:scale-110"
+                      title={favorites.includes(pattern.id) ? "Unsave" : "Save"}
+                    >
+                      {favorites.includes(pattern.id) ? "❤️" : "🤍"}
+                    </button>
                     {/* Pattern style */}
                     <div className="absolute inset-0" style={pattern.style} />
 
@@ -252,10 +293,11 @@ export default function PatternShowcase({
                           e.stopPropagation();
                           copyToClipboard(pattern.code, pattern.id);
                         }}
-                        className={`flex-1 border-0 text-xs h-8 ${copiedId === pattern.id
+                        className={`flex-1 border-0 text-xs h-8 ${
+                          copiedId === pattern.id
                             ? "bg-gray-700 hover:bg-gray-800 text-white"
                             : "bg-gray-900/90 hover:bg-gray-900 text-white"
-                          }`}
+                        }`}
                         disabled={copiedId === pattern.id}
                       >
                         {copiedId === pattern.id ? (
@@ -297,10 +339,11 @@ export default function PatternShowcase({
                               e.stopPropagation();
                               copyToClipboard(pattern.code, pattern.id);
                             }}
-                            className={`cursor-pointer shadow-xl backdrop-blur-md gap-1 border-0 transition-all duration-200 hover:scale-105 text-xs sm:text-sm px-3 py-2 h-auto w-full xs:w-auto ${copiedId === pattern.id
+                            className={`cursor-pointer shadow-xl backdrop-blur-md gap-1 border-0 transition-all duration-200 hover:scale-105 text-xs sm:text-sm px-3 py-2 h-auto w-full xs:w-auto ${
+                              copiedId === pattern.id
                                 ? "bg-gray-700 hover:bg-gray-800 text-white border border-gray-500"
                                 : "bg-gray-900/90 hover:bg-gray-900 text-white"
-                              }`}
+                            }`}
                             disabled={copiedId === pattern.id}
                           >
                             {copiedId === pattern.id ? (


### PR DESCRIPTION
**📋 Description:**
This PR introduces a "Save to Favorites" feature that allows users to bookmark patterns they like and access them anytime:

![image](https://github.com/user-attachments/assets/5803a67e-62d7-4ecf-8edc-92660dc91b61)

**✅ Features Added:**
❤️ Heart toggle button on each pattern card (top-left corner)

💾 Persistence using localStorage so favorites stay saved even after reload

🧠 Favorites state is managed using React hooks

🗂 Added a new "favorites" category (you can optionally display this in the tabs)

🔄 Seamless sync between UI and localStorage



**🧪 How to Test:**
Open any pattern.

Click the ❤️ icon (turns red when saved).

Refresh the page — the favorite remains saved.

Navigate to the "❤️ Saved" tab (if shown) to view only saved patterns.


**📌 Notes:**
Let me know if you'd prefer a different icon or want the saved section in the navbar or a dedicated page.

UI placement and visibility of the "Saved" tab can be customized based on feedback.

