### PR TITLE
feat(ui): add return-to-preview button to improve Preview Flow

### DIFF
--- a/src/app/components/ReturnToPreview.tsx
+++ b/src/app/components/ReturnToPreview.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { ArrowDown } from 'lucide-react';
+import { useEffect, useState, useRef } from 'react';
+
+interface ReturnToPreviewProps {
+    theme?: "light" | "dark";
+}
+
+export default function ReturnToPreview({ theme = "light" }: ReturnToPreviewProps) {
+    const [showButton, setShowButton] = useState(false);
+    const [hasScrolledDown, setHasScrolledDown] = useState(false);
+    const savedScrollY = useRef<number>(0);
+    const [tooltipVisible, setTooltipVisible] = useState(false);
+
+    const saveScrollPosition = (position: number) => {
+        savedScrollY.current = position;
+        setHasScrolledDown(true);
+    };
+
+    const handlePreviewClick = () => {
+        saveScrollPosition(window.scrollY);
+    };
+
+    useEffect(() => {
+        const onScroll = () => {
+            const currentScrollY = window.scrollY;
+            setShowButton(hasScrolledDown && currentScrollY < 150);
+        };
+
+        window.addEventListener('scroll', onScroll);
+        return () => window.removeEventListener('scroll', onScroll);
+    }, [hasScrolledDown]);
+
+    const handleReturn = () => {
+        window.scrollTo({
+            top: savedScrollY.current,
+            behavior: 'smooth'
+        });
+        setShowButton(false);
+    };
+
+    useEffect(() => {
+        if (!showButton) return;
+        setTooltipVisible(true);
+      
+        const timer = setTimeout(() => {
+          setTooltipVisible(false);
+        }, 3000);
+      
+        return () => clearTimeout(timer);
+      }, [showButton]);
+
+    return (
+        <>
+            <span id="trigger-preview-scroll" style={{ display: 'none' }} aria-hidden="true" onClick={handlePreviewClick} />
+            {showButton && (
+                <div className='fixed bottom-20 right-4 sm:right-6 z-50 inline-block'>
+                    <Button
+                        className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full backdrop-blur-md border shadow-xl flex items-center justify-center transition-all duration-300 cursor-pointer ${theme === "dark"
+                                ? "bg-black/50 border-white/8 text-white hover:bg-black/40"
+                                : "bg-white border-gray-300 text-black hover:bg-gray-50"
+                            }`}
+                        onClick={handleReturn}
+                        aria-label='Return back to preview'
+                    >
+                        <ArrowDown className="size-4" />
+                    </Button>
+                    {/* tooltip */}
+                 {
+                        tooltipVisible && (
+                            <span
+                            className={`absolute top-1/2 right-full mr-2 -translate-y-1/2 
+                   whitespace-nowrap px-2 py-1.5 text-xs rounded-md shadow-lg  
+                   backdrop-blur-sm z-50 bg-white border `}
+                        >
+                            Return back to preview
+                            {/*  arrow */}
+                            <span
+                                className={`absolute w-2 h-2  rotate-45 top-1/2 -translate-y-1/2 -right-1 bg-white border-t border-r}`}
+                            />
+                        </span>
+                        )
+                 }
+
+                </div>
+            )}
+        </>
+    );
+}

--- a/src/app/components/pattern-showcase.tsx
+++ b/src/app/components/pattern-showcase.tsx
@@ -240,6 +240,7 @@ export default function PatternShowcase({
                         onClick={(e) => {
                           e.stopPropagation();
                           previewPattern(pattern.id);
+                          document.getElementById('trigger-preview-scroll')?.click()
                         }}
                         className="flex-1 bg-white/95 hover:bg-white text-black border-0 text-xs h-8"
                       >
@@ -285,6 +286,7 @@ export default function PatternShowcase({
                             onClick={(e) => {
                               e.stopPropagation();
                               previewPattern(pattern.id);
+                              document.getElementById('trigger-preview-scroll')?.click()
                             }}
                             className="cursor-pointer shadow-xl backdrop-blur-md bg-white/95 hover:bg-white text-black border-0 transition-all duration-200 hover:scale-105 text-xs sm:text-sm px-3 py-2 h-auto w-full xs:w-auto"
                           >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from "./components/theme-provider";
 import { gridPatterns } from "./utils/patterns";
 import { Toaster } from "sonner";
 import SupportDropdown from "./components/SupportDropdownProps ";
+import ReturnToPreview from "./components/ReturnToPreview";
 
 export default function Home() {
   const [activePattern, setActivePattern] = useState<string | null>(null);
@@ -61,6 +62,7 @@ export default function Home() {
             />
             <Footer theme={theme} />
           </div>
+          <ReturnToPreview theme={theme}  />
         </div>
         <Toaster />
       </ThemeProvider>


### PR DESCRIPTION
This **PR** introduces a **"Return to Preview"** button that enhances user navigation by allowing a seamless transition back to the preview state from the settings view.

### ✨ What's Included:
-  Added a Return to Preview button with responsive styles and mobile support.
- Integrated tooltip logic with automatic hide behavior with delay of 3s.
- Improved performance by avoiding blocking click handlers

### 📷 Demo Screenshot:

https://github.com/user-attachments/assets/27a2a50c-4d8d-447d-9699-b012b258fbdb

### 🧪 Tested On:
- Desktop (Chrome, Firefox)
- Mobile (Chrome)
- Light and Dark Themes