### PR TITLE
feat: add new background gradients

### DIFF
--- a/src/app/utils/patterns.ts
+++ b/src/app/utils/patterns.ts
@@ -3138,7 +3138,7 @@ export const gridPatterns: Pattern[] = [
       `,
     },
     code: `<div className="min-h-screen w-full bg-black relative">
-    {/* Morning Haze */}
+    {/* Midnight Mist */}
     <div
       className="absolute inset-0 z-0"
       style={{


### PR DESCRIPTION
### Add two new background gradients: Morning Haze and Midnight Mist

I’ve added two new background gradients inspired by sunrise and nighttime atmospheres.

🌅 Morning Haze: soft, gentle tones capturing the calm and misty feeling of dawn
🌌 Midnight Mist: dark, mysterious hues evoking the mystique of the night

![morning-haze-midnight-mist](https://github.com/user-attachments/assets/cc1a1b99-9459-414f-9e73-c5e49c1bf930)
