### PR TITLE
feat: add Favourites Patterns category to save your favourite patterns for easy access

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://patterncraft.fun</loc><lastmod>2025-07-11T16:38:16.884Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://patterncraft.fun</loc><lastmod>2025-07-12T06:23:22.040Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/components/pattern-showcase.tsx
+++ b/src/app/components/pattern-showcase.tsx
@@ -55,7 +55,7 @@ export default function PatternShowcase({
     { id: "geometric", label: "Geometric" },
     { id: "decorative", label: "Decorative" },
     { id: "effects", label: "Effects" },
-    { id: "favourites", label: "Saved ⭐" }
+    { id: "favourites", label: "Favourites" }
   ];
 
   // filter patterns based on categories
@@ -233,7 +233,7 @@ export default function PatternShowcase({
               {filteredPatterns.map((pattern) => (
                 <div key={pattern.id} className="group relative">
                   <div
-                    className={`relative aspect-square rounded-xl sm:rounded-2xl overflow-hidden bg-background shadow-sm transition-all duration-300 ${activePattern === pattern.id
+                    className={`relative aspect-square rounded-xl sm:rounded-2xl overflow-hidden shadow-sm transition-all duration-300 ${activePattern === pattern.id
                       ? "ring-2 ring-primary ring-offset-2"
                       : ""
                       } ${activeMobileCard === pattern.id
@@ -253,8 +253,8 @@ export default function PatternShowcase({
                           ? "bg-yellow-500/20 border-yellow-400/30 text-yellow-400"
                           : "bg-yellow-500/20 border-yellow-500/30 text-yellow-600"
                         : isPatternDark
-                          ? "bg-black/20 border-white/20 text-white hover:bg-black/30"
-                          : "bg-white/20 border-gray-200/30 text-gray-600 hover:bg-white/30"
+                          ? "bg-black/20 border-white/20 text-white hover:bg-black/30 hover:border-white/30"
+                          : "bg-black/20 border-white/30 text-white hover:bg-black/30 hover:border-white/40"
                         }`}
                       title={favourite.includes(pattern.id) ? "Remove from favorites" : "Add to favorites"}
                     >
@@ -387,7 +387,7 @@ export default function PatternShowcase({
                       No favourites yet
                     </h3>
                     <p className="text-muted-foreground">
-                      You haven&apos;t saved any patterns. Tap the <Star className="inline -mt-1 h-4 w-4 text-yellow-400" /> icon on a pattern to add it to your favorites!
+                      You haven&apos;t saved any favorites yet. Tap the <Star className="inline -mt-1 h-4 w-4 text-yellow-400" /> icon on a pattern to add it to your favorites!
                     </p>
                   </>
                 ) : (


### PR DESCRIPTION
## ⭐ Add Favourites Patterns Category for Easy Access

### **Overview**
This PR introduces a **"Favourites"** category in the Pattern Showcase, allowing users to save and revisit their favorite patterns easily.

---
<img width="1920" height="963" alt="image" src="https://github.com/user-attachments/assets/05cbc7a2-f8a0-4941-bf4a-0f2e3287d228" />
<img width="1920" height="956" alt="image" src="https://github.com/user-attachments/assets/45d130d9-a380-4e2b-a4c8-06e1ac27b813" />


### **Feature**

- **⭐ Star Button** on each pattern card to mark as favorite
- **Persistent Storage** using `localStorage` favorites stay saved after reloads
- **Saved ⭐ Tab** added to filter bar to view favorited patterns only
- **Instant Feedback** with yellow-filled stars and smooth animations
- **Mobile-Friendly Design** with touch-optimized buttons
- **Empty State UI** when no favorites are saved

---

###  **How to Test ??**

1. Open any pattern in the showcase
2. Click the ⭐ icon to save it
3. Refresh the page  the pattern remains starred
4. Go to the **Saved ⭐** tab to view your favorites
5. Test on both desktop and mobile for responsiveness

---

### ⚠️ Notes

- Uses `localStorage`, which may need adjustment in certain environments like artifact previews
- Inspired by feature request from @saeedsaiyed01  
- Closes #15

---

Thanks for the suggestion, @saeedsaiyed01 🙏🏻
