### PR TITLE
Enhance pattern showcase with pattern filtering by theme category

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { gridPatterns } from "./utils/patterns";
 import { Toaster } from "sonner";
 import SupportDropdown from "./components/SupportDropdownProps ";
 import ReturnToPreview from "./components/ReturnToPreview";
+import { getPatternTheme } from "./types/pattern";
 
 export default function Home() {
   const [activePattern, setActivePattern] = useState<string | null>(null);
@@ -23,17 +24,7 @@ export default function Home() {
   // Update theme based on pattern background color
   useEffect(() => {
     if (activePatternObj) {
-      // Check if pattern ID starts with "dark-" or contains specific dark colors
-      const background = activePatternObj.style.background || "";
-      const isDark =
-        activePatternObj.id.startsWith("dark-") ||
-        (typeof background === "string" &&
-          (background.includes("#0") ||
-            background.includes("#1") ||
-            background.includes("rgba(0,") ||
-            background.includes("rgba(1,")));
-
-      setTheme(isDark ? "dark" : "light");
+      setTheme(getPatternTheme(activePatternObj));
     } else {
       setTheme("light");
     }

--- a/src/app/types/pattern.ts
+++ b/src/app/types/pattern.ts
@@ -9,3 +9,16 @@ export interface Pattern {
   style: CSSProperties
   code: string
 }
+
+// TODO: Make this more robust, e.g. by checking if the background color is in a dark color range
+export function getPatternTheme({ id, style: { background } }: Pattern): 'dark' | 'light' {
+  if (id.startsWith("dark-") ||
+        (typeof background === "string" &&
+          (background.includes("#0") ||
+            background.includes("#1") ||
+            background.includes("rgba(0,") ||
+            background.includes("rgba(1,")))) {
+    return "dark";
+  }
+  return "light";
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,31 @@
+import { Pattern } from "@/app/types/pattern";
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function getPatternTheme({ id, style }: Pattern): 'dark' | 'light' {
+  if (id.startsWith("dark-") ||
+        (typeof style.background === "string" &&
+          (style.background.includes("#0") ||
+            style.background.includes("#1") ||
+            style.background.includes("rgba(0,") ||
+            style.background.includes("rgba(1,")))) {
+    return "dark";
+  }
+  return "light";
+}
+
+export function isDarkPattern(pattern: Pattern): boolean {
+  return getPatternTheme(pattern) === "dark";
+}
+
+export function isLightPattern(pattern: Pattern): boolean {
+  return getPatternTheme(pattern) === "light";
+}
+
+export function makePatternFilterByCategory(category: string) {
+  return (pattern: Pattern) => pattern.category === category;
+};


### PR DESCRIPTION
This is feature that found myself wanting and I noticed it's currently missing. The feature allows to quickly filter the available patterns by pattern theme: "dark" or "light".

Feel free close this PR if you think it's unnecessary 😁

How it looks now (looks nice also in desktop and mobile views):

https://github.com/user-attachments/assets/9d89b644-e7ce-4274-9e2c-e13f2754ca75

