### PR TITLE
feat(ui): add new GPT-5 backgrounds

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://patterncraft.fun</loc><lastmod>2025-08-07T20:04:35.366Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://patterncraft.fun</loc><lastmod>2025-08-08T13:38:00.277Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/data/patterns.ts
+++ b/src/data/patterns.ts
@@ -860,6 +860,138 @@ export const gridPatterns: Pattern[] = [
   },
 
   // Warm Backgrounds
+    {
+    id: "aurora-dream-corner-whispers",
+    name: "Aurora Dream Corner Whispers",
+    category: "effects",
+    badge: "New",
+    style: {
+      background: "#f7eaff",
+      backgroundImage: `
+       radial-gradient(ellipse 85% 65% at 8% 8%, rgba(175, 109, 255, 0.42), transparent 60%),
+            radial-gradient(ellipse 75% 60% at 75% 35%, rgba(255, 235, 170, 0.55), transparent 62%),
+            radial-gradient(ellipse 70% 60% at 15% 80%, rgba(255, 100, 180, 0.40), transparent 62%),
+            radial-gradient(ellipse 70% 60% at 92% 92%, rgba(120, 190, 255, 0.45), transparent 62%),
+            linear-gradient(180deg, #f7eaff 0%, #fde2ea 100%)
+    `,
+      backgroundSize: "100% 100%",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Aurora Dream Corner Whispers */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: \`
+        radial-gradient(ellipse 85% 65% at 8% 8%, rgba(175, 109, 255, 0.42), transparent 60%),
+            radial-gradient(ellipse 75% 60% at 75% 35%, rgba(255, 235, 170, 0.55), transparent 62%),
+            radial-gradient(ellipse 70% 60% at 15% 80%, rgba(255, 100, 180, 0.40), transparent 62%),
+            radial-gradient(ellipse 70% 60% at 92% 92%, rgba(120, 190, 255, 0.45), transparent 62%),
+            linear-gradient(180deg, #f7eaff 0%, #fde2ea 100%)
+      \`,
+    }}
+  />
+  {/* Your content goes here */}
+</div>`,
+  },
+  {
+    id: "aurora-dream-soft-harmony",
+    name: "Aurora Dream Soft Harmony",
+    category: "effects",
+    badge: "New",
+    style: {
+      background: "#f7eaff",
+      backgroundImage: `
+      radial-gradient(ellipse 80% 60% at 60% 20%, rgba(175, 109, 255, 0.50), transparent 65%),
+        radial-gradient(ellipse 70% 60% at 20% 80%, rgba(255, 100, 180, 0.45), transparent 65%),
+        radial-gradient(ellipse 60% 50% at 60% 65%, rgba(255, 235, 170, 0.43), transparent 62%),
+        radial-gradient(ellipse 65% 40% at 50% 60%, rgba(120, 190, 255, 0.48), transparent 68%),
+        linear-gradient(180deg, #f7eaff 0%, #fde2ea 100%)
+    `,
+      backgroundSize: "100% 100%",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Aurora Dream Soft Harmony */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: \`
+       radial-gradient(ellipse 80% 60% at 60% 20%, rgba(175, 109, 255, 0.50), transparent 65%),
+        radial-gradient(ellipse 70% 60% at 20% 80%, rgba(255, 100, 180, 0.45), transparent 65%),
+        radial-gradient(ellipse 60% 50% at 60% 65%, rgba(255, 235, 170, 0.43), transparent 62%),
+        radial-gradient(ellipse 65% 40% at 50% 60%, rgba(120, 190, 255, 0.48), transparent 68%),
+        linear-gradient(180deg, #f7eaff 0%, #fde2ea 100%)
+      \`,
+    }}
+  />
+  {/* Your content goes here */}
+</div>`,
+  },
+  {
+    id: "aurora-dream-diagonal-flow",
+    name: "Aurora Dream Diagonal Flow",
+    category: "effects",
+    badge: "New",
+    style: {
+      background: "#f7eaff",
+      backgroundImage: `
+       radial-gradient(ellipse 80% 60% at 5% 40%, rgba(175, 109, 255, 0.48), transparent 67%),
+        radial-gradient(ellipse 70% 60% at 45% 45%, rgba(255, 100, 180, 0.41), transparent 67%),
+        radial-gradient(ellipse 62% 52% at 83% 76%, rgba(255, 235, 170, 0.44), transparent 63%),
+        radial-gradient(ellipse 60% 48% at 75% 20%, rgba(120, 190, 255, 0.36), transparent 66%),
+        linear-gradient(45deg, #f7eaff 0%, #fde2ea 100%)
+    `,
+      backgroundSize: "100% 100%",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Aurora Dream Diagonal Flow */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: \`
+         radial-gradient(ellipse 80% 60% at 5% 40%, rgba(175, 109, 255, 0.48), transparent 67%),
+        radial-gradient(ellipse 70% 60% at 45% 45%, rgba(255, 100, 180, 0.41), transparent 67%),
+        radial-gradient(ellipse 62% 52% at 83% 76%, rgba(255, 235, 170, 0.44), transparent 63%),
+        radial-gradient(ellipse 60% 48% at 75% 20%, rgba(120, 190, 255, 0.36), transparent 66%),
+        linear-gradient(45deg, #f7eaff 0%, #fde2ea 100%)
+      \`,
+    }}
+  />
+  {/* Your content goes here */}
+</div>`,
+  },
+  {
+    id: "aurora-dream-vivid-bloom",
+    name: "Aurora Dream Vivid Bloom",
+    category: "effects",
+    badge: "New",
+    style: {
+      background: "#f7eaff",
+      backgroundImage: `
+      radial-gradient(ellipse 80% 60% at 70% 20%, rgba(175, 109, 255, 0.85), transparent 68%),
+      radial-gradient(ellipse 70% 60% at 20% 80%, rgba(255, 100, 180, 0.75), transparent 68%),
+      radial-gradient(ellipse 60% 50% at 60% 65%, rgba(255, 235, 170, 0.98), transparent 68%),
+      radial-gradient(ellipse 65% 40% at 50% 60%, rgba(120, 190, 255, 0.3), transparent 68%),
+      linear-gradient(180deg, #f7eaff 0%, #fde2ea 100%)
+    `,
+      backgroundSize: "100% 100%",
+    },
+    code: `<div className="min-h-screen w-full relative">
+  {/* Aurora Dream Vivid Bloom */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: \`
+        radial-gradient(ellipse 80% 60% at 70% 20%, rgba(175, 109, 255, 0.85), transparent 68%),
+        radial-gradient(ellipse 70% 60% at 20% 80%, rgba(255, 100, 180, 0.75), transparent 68%),
+        radial-gradient(ellipse 60% 50% at 60% 65%, rgba(255, 235, 170, 0.98), transparent 68%),
+        radial-gradient(ellipse 65% 40% at 50% 60%, rgba(120, 190, 255, 0.3), transparent 68%),
+        linear-gradient(180deg, #f7eaff 0%, #fde2ea 100%)
+      \`,
+    }}
+  />
+  {/* Your content goes here */}
+</div>`,
+  },
   {
     id: "dreamy-sky-pink-glow",
     name: "Dreamy Sky Pink Glow",


### PR DESCRIPTION
Added new backgrounds -  @GPT-5 sleek backgrounds 

**preview:**

<img width="1920" height="966" alt="bg-1" src="https://github.com/user-attachments/assets/069ffb95-e98d-467f-ac58-4f8f2d81f361" />
<img width="1920" height="963" alt="bg-2" src="https://github.com/user-attachments/assets/3b36896f-d979-4f25-83bf-d556d7b83b7e" />
<img width="1920" height="969" alt="bg-3" src="https://github.com/user-attachments/assets/aa6a05b6-6602-4c6d-86e5-a80fe9fab7af" />
<img width="1920" height="970" alt="bg-4" src="https://github.com/user-attachments/assets/0a4b8b43-c312-43ec-94e1-e98febb62059" />
