### PR TITLE
fix: invalid qr code in dark theme

### DIFF
--- a/src/components/home/support-dropdown.tsx
+++ b/src/components/home/support-dropdown.tsx
@@ -173,8 +173,8 @@ const SupportDropdown: React.FC<SupportDropdownProps> = ({
               <QRCode
                 value={upiUrl}
                 size={120}
-                bgColor={theme === "dark" ? "#222" : "#fff"}
-                fgColor={theme === "dark" ? "#fff" : "#222"}
+                bgColor="#fff"
+                fgColor="#222"
               />
               <div className="mt-2 text-xs text-center text-gray-500">
                 UPI ID:{" "}


### PR DESCRIPTION
The quiet zone around the QR code is white (bg-white). For the QR code to be valid, the polarity of the markers must match the quiet zone — i.e., black markers on a white background.