### PR TITLE
add new dark circuit board bg (thenkss @TheOrcDev)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://patterncraft.fun</loc><lastmod>2025-08-30T16:55:13.769Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://patterncraft.fun</loc><lastmod>2025-09-04T14:34:08.852Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/data/patterns.ts
+++ b/src/data/patterns.ts
@@ -3722,6 +3722,38 @@ export const gridPatterns: Pattern[] = [
 </div>`,
   },
   {
+    id: "dark-circuit-board",
+    name: "Dark Circuit Board",
+    category: "geometric",
+    badge: "New",
+    style: {
+      backgroundColor: "#171717",
+      backgroundImage: `
+      linear-gradient(90deg, #171717 1px, transparent 1px),
+      linear-gradient(180deg, #171717 1px, transparent 1px),
+      linear-gradient(90deg, #262626 1px, transparent 1px),
+      linear-gradient(180deg, #262626 1px, transparent 1px)
+    `,
+      backgroundSize: "50px 50px, 50px 50px, 10px 10px, 10px 10px",
+    },
+    code: `<div className="min-h-screen w-full relative bg-[#171717]">
+  {/* Dark Circuit Board Background */}
+  <div
+    className="absolute inset-0 z-0 pointer-events-none"
+    style={{
+      backgroundImage: \`
+        linear-gradient(90deg, #171717 1px, transparent 1px),
+        linear-gradient(180deg, #171717 1px, transparent 1px),
+        linear-gradient(90deg, #262626 1px, transparent 1px),
+        linear-gradient(180deg, #262626 1px, transparent 1px)
+      \`,
+      backgroundSize: "50px 50px, 50px 50px, 10px 10px, 10px 10px",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+  },
+  {
     id: "concentric-squares-dark",
     name: "Concentric Squares - Dark",
     category: "geometric",
@@ -4406,8 +4438,8 @@ export const gridPatterns: Pattern[] = [
   />
   {/* Your Content/Components */}
 </div>`,
-},
-{
+  },
+  {
     id: "northern-aurora",
     name: "Northern Aurora",
     category: "effects",


### PR DESCRIPTION
### Dark version of circuit board - light

<img width="1920" height="964" alt="image" src="https://github.com/user-attachments/assets/04aef6ef-608d-4d5d-99f1-d00736f07cee" />
