### PR TITLE
feat: add back to top button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import Hero from "@/components/home/hero";
 import PatternShowcase from "@/components/patterns/pattern-showcase";
 import SupportDropdown from "@/components/home/support-dropdown";
 import ReturnToPreview from "@/components/home/return-to-preview";
+import ScrollToTop from "@/components/ui/scroll-to-top";
 import { FavoritesProvider } from "@/context/favourites-context";
 
 export default function Home() {
@@ -55,6 +56,9 @@ export default function Home() {
               <Footer theme={theme} />
             </div>
             <ReturnToPreview theme={theme} />
+            <div className="fixed bottom-6 right-16 sm:right-20 z-50">
+              <ScrollToTop theme={theme} />
+            </div>
           </div>
         </FavoritesProvider>
         <Toaster />

--- a/src/components/ui/scroll-to-top.tsx
+++ b/src/components/ui/scroll-to-top.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { ChevronUp } from "lucide-react";
+
+interface ScrollToTopProps {
+  theme?: "light" | "dark";
+}
+
+const ScrollToTop: React.FC<ScrollToTopProps> = ({ theme = "light" }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  // Show button when page is scrolled down
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.pageYOffset > 300) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener("scroll", toggleVisibility);
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className={`
+        w-10 h-10 sm:w-12 sm:h-12 rounded-full backdrop-blur-md border shadow-xl
+        flex items-center justify-center transition-all duration-300
+        hover:scale-105 active:scale-95
+        ${
+          theme === "dark"
+            ? "bg-black/50 border-white/10 hover:bg-black/40"
+            : "bg-white border-gray-300 hover:bg-gray-50"
+        }
+      `}
+      aria-label="Scroll to top"
+    >
+      <ChevronUp
+        className={`w-5 sm:w-6 h-5 sm:h-6 ${
+          theme === "dark" ? "text-white/80" : "text-gray-600"
+        }`}
+      />
+    </button>
+  );
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
was scrolling on mobile and theres a lot of patterns and scrolling to the top was a pain.

<img width="172" height="104" alt="image" src="https://github.com/user-attachments/assets/019c290e-d390-441a-893f-cb838f9392a2" />
