### PR TITLE
feat(pattern): add "Cosmic Whisper" background effect

### DIFF
--- a/src/data/patterns.ts
+++ b/src/data/patterns.ts
@@ -6251,4 +6251,33 @@ export const gridPatterns: Pattern[] = [
  {/* Your Content/Components */}
 </div>`,
   },
+  {
+    id: "comic-whisper",
+    name: "Cosmic Whisper",
+    category: "effects",
+    badge: "New",
+    style: {
+      background: `
+      radial-gradient( 120% 80% at 50% 100%, rgba(236, 72, 153, 0.35), transparent 60% ),
+      radial-gradient( 100% 70% at 50% 70%, rgba(139, 92, 246, 0.45), transparent 70% ),
+      radial-gradient( 80% 60% at 50% 40%, rgba(59, 130, 246, 0.4), transparent 80% ),
+      #000 `,
+    },
+    code: `<div className="min-h-screen w-full bg-[#000] relative">
+  {/* Cosmic Whisper */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: \`
+        radial-gradient( 120% 80% at 50% 100%, rgba(236, 72, 153, 0.35), transparent 60% ),
+        radial-gradient( 100% 70% at 50% 70%, rgba(139, 92, 246, 0.45), transparent 70% ),
+        radial-gradient( 80% 60% at 50% 40%, rgba(59, 130, 246, 0.4), transparent 80%
+        ),
+        #000
+      \`,
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+  },
 ];


### PR DESCRIPTION
This PR adds a new pattern called Cosmic Whisper in the "effects" category.

- Layered radial gradients with pink, purple, and blue over black
- Full-screen background effect
- Badge: "New"

Preview: 
<img width="1858" height="936" alt="Screenshot 2025-09-16 152623" src="https://github.com/user-attachments/assets/ab5432a7-1c42-48d5-be38-4f11e2f9c0fb" />
<img width="383" height="836" alt="Screenshot 2025-09-16 152643" src="https://github.com/user-attachments/assets/efa0c292-cb69-4c69-8852-bd75911272cc" />



Notes:
- Works with min-h-screen and full-width layouts
- Content should be placed above the background div

