### PR TITLE
feat: implement sticky tabs for categories

### DIFF
--- a/src/components/patterns/pattern-showcase.tsx
+++ b/src/components/patterns/pattern-showcase.tsx
@@ -70,13 +70,15 @@ export default function PatternShowcase({
         className="w-full mb-8"
       >
         {/* Desktop & Tablet Tabs */}
+        <div className={`sticky top-3 py-4 mb-2 rounded-2xl px-3 z-50 backdrop-blur-lg backdrop-saturate-150
+          ${isPatternDark ? "bg-black/[.80]" : "bg-white/[.85]"}`}>
         <TabsList
           className={`
             hidden md:grid
             grid-cols-2 sm:grid-cols-3 md:grid-cols-6
             w-full h-auto p-1.5
             backdrop-blur-md shadow-lg border
-            rounded-xl mb-8 transition-all duration-300
+            rounded-xl mb-0 md:mb-5 transition-all duration-300
             ${
               isPatternDark
                 ? "bg-black/20 border-white/10 hover:bg-black/30"
@@ -96,7 +98,7 @@ export default function PatternShowcase({
                 transition-all duration-300 ease-in-out
                 min-h-[44px] sm:min-h-[40px]
                 relative overflow-hidden
-                group
+                group cursor-pointer
                 ${
                   isPatternDark
                     ? `data-[state=active]:bg-white/10 data-[state=active]:text-white 
@@ -174,6 +176,7 @@ export default function PatternShowcase({
           setSearchInput={setSearchInput}
           isPatternDark={isPatternDark}
         ></SearchBar>
+        </div>
 
         {categories.map((category) => (
           <TabsContent

--- a/src/components/search/search-bar.tsx
+++ b/src/components/search/search-bar.tsx
@@ -32,7 +32,7 @@ export function SearchBar({
   return (
     <div
       className={`w-full
-    backdrop-blur-md shadow-sm border  rounded-xl mb-8 flex items-center px-2 ${
+    backdrop-blur-md shadow-sm border  rounded-xl flex items-center px-2 ${
       isPatternDark
         ? "bg-black/20 border-white/10 hover:bg-black/30"
         : "bg-white/70 border-gray-200/30 hover:bg-white/80"


### PR DESCRIPTION
This PR makes the category tabs section sticky, so they remain visible while scrolling through the content.
Changes
- Added position: `sticky` to the category tabs container.
- Ensures better navigation by keeping categories accessible at all times.
- Added cursor: `pointer` to each TabsTrigger for better interactivity.

Before:

https://github.com/user-attachments/assets/8cfcc7de-06ef-40e5-9b7a-42b08e135315

After:

https://github.com/user-attachments/assets/1677499c-cfed-4564-88f9-f06a5bdb1c82
