### PR TITLE
fix: remove stray backticks typo in Hero component stats section

### DIFF
--- a/src/components/home/hero.tsx
+++ b/src/components/home/hero.tsx
@@ -223,7 +223,7 @@ export default function Hero({ theme }: HeroProps) {
               Free
             </div>
           </div>
-          <div className="text-center">``
+          <div className="text-center">
             <div
               className={`text-xl sm:text-2xl font-bold transition-colors duration-300 ${isPatternDark ? "text-white" : ""
                 }`}


### PR DESCRIPTION
## Description

This PR fixes a typo in the Hero component where stray backticks (``) were present in the stats section, causing incorrect rendering of the "CSS & Tailwind" text.

## Changes Made

- Removed stray backticks from line 226 in `src/components/home/hero.tsx`
- Fixed the rendering of the "CSS & Tailwind" stat in the Hero component stats section

## Location

- **File**: `src/components/home/hero.tsx`
- **Line**: 226
- **Component**: Hero stats section
<img width="3360" height="1642" alt="image" src="https://github.com/user-attachments/assets/017b5017-7f91-4aaa-9305-a7b726d489c8" />

## Before

<div className="text-center">``
  <div>CSS</div>
  <div>& Tailwind</div>
</div>

<img width="3360" height="1642" alt="image" src="https://github.com/user-attachments/assets/ad5c189f-e7ac-4201-b196-82a0dc6271c6" />

