### PR TITLE
feat: add vanilla HTML copy support for patterns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1629,6 +1629,7 @@
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1639,6 +1640,7 @@
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -1689,6 +1691,7 @@
       "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.33.1",
         "@typescript-eslint/types": "8.33.1",
@@ -2250,6 +2253,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3156,6 +3160,7 @@
       "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3330,6 +3335,7 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -5048,6 +5054,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.3.6.tgz",
       "integrity": "sha512-oI6D1zbbsh6JzzZFDCSHnnx6Qpvd1fSkVJu/5d8uluqnxzuoqtodVZjYvNovooznUq8udSAiKp7MbwlfZ8Gm6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.3.6",
         "@swc/counter": "0.1.3",
@@ -5517,6 +5524,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5526,6 +5534,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6260,6 +6269,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6418,6 +6428,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/components/patterns/pattern-card.tsx
+++ b/src/components/patterns/pattern-card.tsx
@@ -42,13 +42,15 @@ export default function PatternCard({
   return (
     <div className="group relative">
       <div
-        className={`relative aspect-square rounded-xl sm:rounded-2xl overflow-hidden bg-background shadow-sm transition-all duration-300 ${activePattern === pattern.id
+        className={`relative aspect-square rounded-xl sm:rounded-2xl overflow-hidden bg-background shadow-sm transition-all duration-300 ${
+          activePattern === pattern.id
             ? "ring-2 ring-primary ring-offset-2"
             : ""
-          } ${activeMobileCard === pattern.id
+        } ${
+          activeMobileCard === pattern.id
             ? "scale-[1.02] shadow-lg sm:scale-100"
             : "hover:shadow-lg hover:scale-[1.02]"
-          }`}
+        }`}
         onClick={() => handleCardInteraction(pattern.id)}
       >
         {/* Favorite Button with Star Icon */}
@@ -57,14 +59,15 @@ export default function PatternCard({
             e.stopPropagation();
             toggleFavourite(pattern.id);
           }}
-          className={`absolute top-2 left-2 z-10 p-2 rounded-full backdrop-blur-md shadow-lg border transition-all cursor-pointer duration-200 hover:scale-110 group/star ${isFavourite(pattern.id)
+          className={`absolute top-2 left-2 z-10 p-2 rounded-full backdrop-blur-md shadow-lg border transition-all cursor-pointer duration-200 hover:scale-110 group/star ${
+            isFavourite(pattern.id)
               ? isPatternDark
                 ? "bg-yellow-500/20 border-yellow-400/30 text-yellow-400"
                 : "bg-yellow-500/20 border-yellow-500/30 text-yellow-600"
               : isPatternDark
                 ? "bg-black/20 border-white/20 text-white hover:bg-black/30 hover:border-white/30"
                 : "bg-black/20 border-white/30 text-white hover:bg-black/30 hover:border-white/40"
-            }`}
+          }`}
           title={
             isFavourite(pattern.id)
               ? "Remove from favorites"
@@ -72,10 +75,11 @@ export default function PatternCard({
           }
         >
           <Star
-            className={`h-4 w-4 transition-all duration-200 ${isFavourite(pattern.id)
+            className={`h-4 w-4 transition-all duration-200 ${
+              isFavourite(pattern.id)
                 ? "fill-current scale-110"
                 : "group-hover/star:scale-110"
-              }`}
+            }`}
           />
         </button>
 
@@ -116,15 +120,16 @@ export default function PatternCard({
             size="sm"
             onClick={(e) => {
               e.stopPropagation();
-              copyToClipboard(pattern.code, pattern.id);
+              copyToClipboard(pattern);
             }}
-            className={`flex-1 border-0 text-xs h-8 ${isCopied(pattern.id)
+            className={`flex-1 border-0 text-xs h-8 ${
+              isCopied(pattern.id, "react")
                 ? "bg-gray-700 hover:bg-gray-800 text-white"
                 : "bg-gray-900/90 hover:bg-gray-900 text-white"
-              }`}
-            disabled={isCopied(pattern.id)}
+            }`}
+            disabled={isCopied(pattern.id, "react")}
           >
-            {isCopied(pattern.id) ? (
+            {isCopied(pattern.id, "react") ? (
               <>
                 <Check className="h-3 w-3 mr-1" />
                 Copied
@@ -132,7 +137,32 @@ export default function PatternCard({
             ) : (
               <>
                 <Copy className="h-3 w-3 mr-1" />
-                Copy
+                React
+              </>
+            )}
+          </Button>
+          <Button
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              copyToClipboard(pattern, true);
+            }}
+            className={`flex-1 border-0 text-xs h-8 ${
+              isCopied(pattern.id, "vanilla")
+                ? "bg-gray-700 hover:bg-gray-800 text-white"
+                : "bg-gray-900/90 hover:bg-gray-900 text-white"
+            }`}
+            disabled={isCopied(pattern.id, "vanilla")}
+          >
+            {isCopied(pattern.id, "vanilla") ? (
+              <>
+                <Check className="h-3 w-3 mr-1" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Copy className="h-3 w-3 mr-1" />
+                Vanilla
               </>
             )}
           </Button>
@@ -164,15 +194,16 @@ export default function PatternCard({
                 size="sm"
                 onClick={(e) => {
                   e.stopPropagation();
-                  copyToClipboard(pattern.code, pattern.id);
+                  copyToClipboard(pattern);
                 }}
-                className={`cursor-pointer shadow-xl backdrop-blur-md gap-1 border-0 transition-all duration-200 hover:scale-105 text-xs sm:text-sm px-3 py-2 h-auto w-full xs:w-auto ${isCopied(pattern.id)
+                className={`cursor-pointer shadow-xl backdrop-blur-md gap-1 border-0 transition-all duration-200 hover:scale-105 text-xs sm:text-sm px-3 py-2 h-auto w-full xs:w-auto ${
+                  isCopied(pattern.id, "react")
                     ? "bg-gray-700 hover:bg-gray-800 text-white border border-gray-500"
                     : "bg-gray-900/90 hover:bg-gray-900 text-white"
-                  }`}
-                disabled={isCopied(pattern.id)}
+                }`}
+                disabled={isCopied(pattern.id, "react")}
               >
-                {isCopied(pattern.id) ? (
+                {isCopied(pattern.id, "react") ? (
                   <>
                     <Check className="h-3 w-3" />
                     Copied
@@ -180,7 +211,32 @@ export default function PatternCard({
                 ) : (
                   <>
                     <Copy className="h-3 w-3" />
-                    Copy
+                    React
+                  </>
+                )}
+              </Button>
+              <Button
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  copyToClipboard(pattern, true);
+                }}
+                className={`cursor-pointer shadow-xl backdrop-blur-md gap-1 border-0 transition-all duration-200 hover:scale-105 text-xs sm:text-sm px-3 py-2 h-auto w-full xs:w-auto ${
+                  isCopied(pattern.id, "vanilla")
+                    ? "bg-gray-700 hover:bg-gray-800 text-white border border-gray-500"
+                    : "bg-gray-900/90 hover:bg-gray-900 text-white"
+                }`}
+                disabled={isCopied(pattern.id, "vanilla")}
+              >
+                {isCopied(pattern.id, "vanilla") ? (
+                  <>
+                    <Check className="h-3 w-3" />
+                    Copied
+                  </>
+                ) : (
+                  <>
+                    <Copy className="h-3 w-3" />
+                    Vanilla
                   </>
                 )}
               </Button>

--- a/src/hooks/useCopy.tsx
+++ b/src/hooks/useCopy.tsx
@@ -1,24 +1,58 @@
 "use client";
 
+import { Pattern } from "@/types";
 import { useState } from "react";
 import { toast } from "sonner";
 
-export function useCopy() {
-  const [copiedId, setCopiedId] = useState<string | null>(null);
+interface CopiedState {
+  id: string;
+  type: "react" | "vanilla";
+}
 
-  const copyToClipboard = async (code: string, id: string) => {
+export function useCopy() {
+  const [copiedState, setCopiedState] = useState<CopiedState | null>(null);
+
+  const copyToClipboard = async (pattern: Pattern, vanilla = false) => {
     try {
-      await navigator.clipboard.writeText(code);
-      setCopiedId(id);
-      toast.success("Code copied to clipboard!");
-      setTimeout(() => setCopiedId(null), 1000);
-    } catch (error) {
-      console.error("Failed to copy to clipboard:", error);
+      let textToCopy = pattern.code;
+
+      if (vanilla) {
+        const el = document.createElement("div");
+        Object.assign(el.style, {
+          minHeight: "100vh",
+          width: "100%",
+          position: "relative",
+        });
+        const containerStyle = el.getAttribute("style") || "";
+
+        const bg = document.createElement("div");
+        Object.assign(bg.style, {
+          position: "absolute",
+          inset: "0",
+          zIndex: "0",
+          ...pattern.style,
+        });
+        const bgStyle = bg.getAttribute("style") || "";
+
+        textToCopy = `
+<div style="${containerStyle}">
+  <div style="${bgStyle}"></div>
+</div>
+        `.trim();
+      }
+
+      await navigator.clipboard.writeText(textToCopy);
+      setCopiedState({ id: pattern.id, type: vanilla ? "vanilla" : "react" });
+      toast.success("Code copied!");
+      setTimeout(() => setCopiedState(null), 1000);
+    } catch (err) {
+      console.error(err);
       toast.error("Failed to copy code");
     }
   };
 
-  const isCopied = (id: string) => copiedId === id;
+  const isCopied = (id: string, type: "react" | "vanilla" = "react") =>
+    copiedState?.id === id && copiedState?.type === type;
 
   return {
     copyToClipboard,


### PR DESCRIPTION
## Summary
Adds support for copying patterns as vanilla HTML in addition to React code.

## Changes
- Updated [`useCopy`](https://github.com/Lahnshen/pattern-craft/blob/feature/add-vanilla-support/src/hooks/useCopy.tsx) hook to generate vanilla HTML from pattern styles.
  - The hook now takes the entire pattern object instead of just `pattern.code` in the `pattern` parameter.
  - The hook now has a boolean `vanilla` parameter which specifies whether it should copy the `pattern.code` or convert `pattern.style` to a vanilla div element and copy that instead.  
- Added separate "React" and "Vanilla" copy buttons in pattern card components.

## How it works
The vanilla output applies all `pattern.style` properties to a child div similar to how the pattern card component does ([`pattern-card.tsx:87`](https://github.com/Lahnshen/pattern-craft/blob/feature/add-vanilla-support/src/components/patterns/pattern-card.tsx#L87)) and copies that to the clipboard of the user.