### PR TITLE
feat: add subtle white heart grid texture

### DIFF
--- a/src/data/patterns.ts
+++ b/src/data/patterns.ts
@@ -1,6 +1,31 @@
 import { Pattern } from "@/types/pattern";
 
 export const gridPatterns: Pattern[] = [
+{
+  id: "heart-grid",
+  name: " Heart Grid",
+  category: "geometric",
+  badge: "New",
+  style: {
+    background: "#ffffff",
+    backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 24 24' fill='rgba(0, 0, 0, 0.07)'%3E%3Cpath d='M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z'/%3E%3C/svg%3E")`,
+    backgroundSize: "24px 24px",
+  },
+  code: `<div className="min-h-screen w-full bg-white relative">
+  {/* Subtle White Heart Grid */}
+  <div
+    className="absolute inset-0 z-0"
+    style={{
+      background: "#ffffff",
+      backgroundImage: \`url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 24 24' fill='rgba(0, 0, 0, 0.07)'%3E%3Cpath d='M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z'/%3E%3C/svg%3E")\`,
+      backgroundSize: "24px 24px",
+      backgroundPosition: "center",
+      backgroundRepeat: "repeat",
+    }}
+  />
+  {/* Your Content/Components */}
+</div>`,
+},
   {
     id: "top-gradient-radial",
     name: "Top Gradient Radial",


### PR DESCRIPTION
Title: feat: add minimalist white heart grid pattern

Description:
Added a delicate, sophisticated heart-shaped dot grid designed for white background contexts.

Key Features:

Micro Detail: Each heart is a "tiny spec" (8px wide) to read as a subtle dot from a distance, revealing the heart detail only upon closer inspection.

Minimalist Spacing: Features a wide (24px) grid pattern, ensuring high "negative space" and keeping the aesthetic clean and airy.

Subtle Opacity: Uses low 0.07 opacity grey (rgba(0, 0, 0, 0.07)) to ensure the texture doesn't fight with content or seem like heavy noise.

Perfectly suited for a polished hero section or custom stationery-feel landing pages.

<img width="1916" height="895" alt="image" src="https://github.com/user-attachments/assets/d81e2adc-fe22-4ab1-8f47-94dfef62c884" />
<img width="565" height="833" alt="image" src="https://github.com/user-attachments/assets/51f984fd-5ba3-4e01-82f2-7cfbe19d27b2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a heart-themed geometric grid pattern with a white background and subtle repeating heart texture.
  - Included a ready-to-use JSX example for the new pattern.
  - The pattern is available as a separate selectable design option and uses consistent sizing for a clean, repeatable appearance.
  - Existing pattern options remain available alongside the new heart design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->