### PR TITLE
fix: update star history chart to working host

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,11 +408,11 @@ If you like this project, consider giving it a ⭐️ on GitHub and sharing it w
 
 ## Star History
 
-<a href="https://www.star-history.com/#megh-bari/pattern-craft&Date">
+<a href="https://star-history.dera.page/#megh-bari/pattern-craft&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=megh-bari/pattern-craft&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=megh-bari/pattern-craft&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=megh-bari/pattern-craft&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=megh-bari/pattern-craft&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=megh-bari/pattern-craft&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=megh-bari/pattern-craft&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the old host can no longer render it reliably due to GitHub stargazer API restrictions. This PR points the chart and its link to a working host so the chart displays correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Star History links and chart sources to use the new hosting domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->