### PR TITLE
feat: add beach effect pattern

### DIFF
--- a/src/data/patterns.ts
+++ b/src/data/patterns.ts
@@ -1,6 +1,46 @@
 import { Pattern } from "@/types/pattern";
 
 export const gridPatterns: Pattern[] = [
+{
+  id: "beach",
+  name: "Beach",
+  category: "effects",
+  badge: "New",
+  style: {
+    background: "#E7DFD3", 
+    backgroundImage: `
+      radial-gradient(circle at 50% 50%, transparent 75%, rgba(255,244,190,0.5) 100%),
+      linear-gradient(180deg, 
+        rgba(205, 235, 250, 1) 0%,
+        rgba(255, 244, 224, 1) 35%,
+        rgba(255, 226, 194, 1) 70%,
+        rgba(255, 198, 142, 1) 80%,
+        rgba(245, 145, 115, 1) 90%,
+        rgba(190, 91, 91, 1) 100%
+      )
+    `,
+  },
+  code: `<div className="min-h-screen w-full bg-[#E7DFD3] relative">
+    {/* Effects Beach Background */}
+    <div
+      className="absolute inset-0 z-0"
+      style={{
+        backgroundImage: \`
+          radial-gradient(circle at 50% 50%, transparent 75%, rgba(255,244,190,0.5) 100%),
+          linear-gradient(180deg,
+            rgba(205, 235, 250, 1) 0%,
+            rgba(255, 244, 224, 1) 35%,
+            rgba(255, 226, 194, 1) 70%,
+            rgba(255, 198, 142, 1) 80%,
+            rgba(245, 145, 115, 1) 90%,
+            rgba(190, 91, 91, 1) 100%
+          )
+        \`, 
+      }}
+    />
+    {/* Your Content/Components */}
+  </div>`,
+},
   {
     id: "top-gradient-radial",
     name: "Top Gradient Radial",


### PR DESCRIPTION
Add new gradient effect like beach.

<img width="1578" height="1084" alt="beach-d" src="https://github.com/user-attachments/assets/cd7a4aac-a73c-4cc6-85eb-4e5d57556273" />

<img width="612" height="1084" alt="beach-m" src="https://github.com/user-attachments/assets/55e5dc5a-37aa-43c8-9fe0-109e010bdf8e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Beach” effects pattern featuring a beige base with layered beach and sunset gradients.
  * Included ready-to-use JSX code for applying the pattern.
  * Marked the pattern as “New” in the pattern collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->